### PR TITLE
feat: add automation tools section with SZ-ACL web app

### DIFF
--- a/index.html
+++ b/index.html
@@ -143,6 +143,7 @@
                 <a href="index.html" class="nav-link active">home</a>
                 <a href="projects.html" class="nav-link">projects</a>
                 <a href="skills.html" class="nav-link">skills</a>
+                <a href="tools.html" class="nav-link">tools</a>
                 <a href="https://github.com/neuralconfig" class="nav-link external">github</a>
             </div>
         </div>
@@ -160,6 +161,7 @@
         
         <div class="cta-buttons">
             <a href="projects.html" class="cta-button primary">View Projects</a>
+            <a href="tools.html" class="cta-button">Automation Tools</a>
             <a href="skills.html" class="cta-button">Technical Skills</a>
             <a href="mailto:contact@neuralconfig.com" class="cta-button">Get In Touch</a>
         </div>

--- a/openrouter-chat-app.html
+++ b/openrouter-chat-app.html
@@ -132,6 +132,7 @@
                 <a href="index.html" class="nav-link">home</a>
                 <a href="projects.html" class="nav-link">projects</a>
                 <a href="skills.html" class="nav-link">skills</a>
+                <a href="tools.html" class="nav-link">tools</a>
                 <a href="https://github.com/neuralconfig" class="nav-link external">github</a>
             </div>
         </div>

--- a/osticket-agent.html
+++ b/osticket-agent.html
@@ -166,6 +166,7 @@
                 <a href="index.html" class="nav-link">home</a>
                 <a href="projects.html" class="nav-link">projects</a>
                 <a href="skills.html" class="nav-link">skills</a>
+                <a href="tools.html" class="nav-link">tools</a>
                 <a href="https://github.com/neuralconfig" class="nav-link external">github</a>
             </div>
         </div>

--- a/pflogs.html
+++ b/pflogs.html
@@ -185,6 +185,7 @@
                 <a href="index.html" class="nav-link">home</a>
                 <a href="projects.html" class="nav-link">projects</a>
                 <a href="skills.html" class="nav-link">skills</a>
+                <a href="tools.html" class="nav-link">tools</a>
                 <a href="https://github.com/neuralconfig" class="nav-link external">github</a>
             </div>
         </div>

--- a/projects.html
+++ b/projects.html
@@ -16,6 +16,7 @@
                 <a href="index.html" class="nav-link">home</a>
                 <a href="projects.html" class="nav-link active">projects</a>
                 <a href="skills.html" class="nav-link">skills</a>
+                <a href="tools.html" class="nav-link">tools</a>
                 <a href="https://github.com/neuralconfig" class="nav-link external">github</a>
             </div>
         </div>

--- a/skills.html
+++ b/skills.html
@@ -16,6 +16,7 @@
                 <a href="index.html" class="nav-link">home</a>
                 <a href="projects.html" class="nav-link">projects</a>
                 <a href="skills.html" class="nav-link active">skills</a>
+                <a href="tools.html" class="nav-link">tools</a>
                 <a href="https://github.com/neuralconfig" class="nav-link external">github</a>
             </div>
         </div>

--- a/survival-rag.html
+++ b/survival-rag.html
@@ -141,6 +141,7 @@
                 <a href="index.html" class="nav-link">home</a>
                 <a href="projects.html" class="nav-link">projects</a>
                 <a href="skills.html" class="nav-link">skills</a>
+                <a href="tools.html" class="nav-link">tools</a>
                 <a href="https://github.com/neuralconfig" class="nav-link external">github</a>
             </div>
         </div>

--- a/sz-acl.html
+++ b/sz-acl.html
@@ -139,6 +139,7 @@
                 <a href="index.html" class="nav-link">home</a>
                 <a href="projects.html" class="nav-link">projects</a>
                 <a href="skills.html" class="nav-link">skills</a>
+                <a href="tools.html" class="nav-link">tools</a>
                 <a href="https://github.com/neuralconfig" class="nav-link external">github</a>
             </div>
         </div>
@@ -163,13 +164,18 @@
         <section class="section">
             <h2><span class="terminal-prompt">></span> Overview</h2>
             <p style="line-height: 1.8; margin-bottom: 1rem;">
-                An advanced Access Control List (ACL) management system designed for enterprise network security. 
-                SZ-ACL automates the complex task of ACL rule generation, validation, and deployment while providing 
-                intelligent conflict detection and resolution capabilities.
+                An advanced Access Control List (ACL) management system designed for Ruckus SmartZone enterprise networks. 
+                SZ-ACL provides both CLI tools and a web interface to automate the complex task of ACL rule generation, 
+                validation, and deployment while providing intelligent conflict detection and resolution capabilities.
             </p>
-            <p style="line-height: 1.8;">
+            <p style="line-height: 1.8; margin-bottom: 1rem;">
                 This project addresses the critical challenge of maintaining secure, efficient network policies at scale, 
                 combining security best practices with automation to reduce human error and improve network performance.
+            </p>
+            <p style="line-height: 1.8;">
+                <strong>Now available as a web application:</strong> The SZ-ACL tool is deployed on Google Cloud Platform 
+                and accessible at <a href="https://szacl.neuralconfig.com" style="color: var(--neon-green);">szacl.neuralconfig.com</a>, 
+                providing a user-friendly interface for managing Layer 3 Access Control Policies without CLI expertise.
             </p>
         </section>
 
@@ -177,20 +183,20 @@
             <h2><span class="terminal-prompt">></span> Key Features</h2>
             <div class="feature-grid">
                 <div class="feature-card">
-                    <h3>Rule Generation</h3>
-                    <p>Automated ACL rule creation based on security policies and network topology</p>
+                    <h3>Web Interface</h3>
+                    <p>User-friendly web app deployed on Google Cloud for easy ACL management</p>
                 </div>
                 <div class="feature-card">
-                    <h3>Conflict Detection</h3>
-                    <p>Advanced algorithms to identify and resolve rule conflicts before deployment</p>
+                    <h3>Bulk Operations</h3>
+                    <p>Support for CSV import/export and bulk policy creation across network segments</p>
                 </div>
                 <div class="feature-card">
-                    <h3>Performance Optimization</h3>
-                    <p>Rule ordering and consolidation for optimal packet processing</p>
+                    <h3>Wildcard Support</h3>
+                    <p>Template-based ACL creation with wildcard replacement for multi-site deployments</p>
                 </div>
                 <div class="feature-card">
-                    <h3>Audit Trail</h3>
-                    <p>Comprehensive logging and change tracking for compliance</p>
+                    <h3>Rate Limiting</h3>
+                    <p>Firewall profile configuration with integrated rate limiting capabilities</p>
                 </div>
             </div>
         </section>
@@ -228,11 +234,11 @@
             <h2><span class="terminal-prompt">></span> Technology Stack</h2>
             <div class="tech-stack">
                 <div class="tech-item">Python 3.11+</div>
-                <div class="tech-item">NetworkX</div>
-                <div class="tech-item">Pandas</div>
-                <div class="tech-item">Cisco/Juniper APIs</div>
-                <div class="tech-item">Redis</div>
-                <div class="tech-item">FastAPI</div>
+                <div class="tech-item">Google App Engine</div>
+                <div class="tech-item">Ruckus SmartZone API</div>
+                <div class="tech-item">Requests</div>
+                <div class="tech-item">CSV/JSON Processing</div>
+                <div class="tech-item">Cloud Deployment</div>
             </div>
         </section>
 
@@ -250,7 +256,8 @@
         </section>
 
         <div class="project-actions">
-            <a href="https://github.com/neuralconfig/sz-acl" class="action-button primary">View on GitHub</a>
+            <a href="https://szacl.neuralconfig.com" class="action-button primary">Try Web App</a>
+            <a href="https://github.com/neuralconfig/sz-acl" class="action-button">View on GitHub</a>
             <a href="projects.html" class="action-button">Back to Projects</a>
         </div>
     </div>

--- a/tools.html
+++ b/tools.html
@@ -1,0 +1,208 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Tools | neuralconfig</title>
+    <link rel="stylesheet" href="styles.css">
+    <style>
+        .tools-header {
+            text-align: center;
+            margin-bottom: 3rem;
+            padding-bottom: 2rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+        
+        .tools-title {
+            font-size: 2.5rem;
+            color: var(--neon-green);
+            margin-bottom: 1rem;
+        }
+        
+        .tools-subtitle {
+            opacity: 0.8;
+            line-height: 1.6;
+            max-width: 600px;
+            margin: 0 auto;
+        }
+        
+        .tools-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
+            gap: 2rem;
+            margin-top: 3rem;
+        }
+        
+        .tool-card {
+            background: rgba(5, 5, 5, 0.8);
+            border: 1px solid var(--border-color);
+            border-radius: 4px;
+            padding: 2rem;
+            transition: all 0.3s ease;
+            cursor: pointer;
+            text-decoration: none;
+            color: inherit;
+            display: block;
+        }
+        
+        .tool-card:hover {
+            transform: translateY(-5px);
+            border-color: var(--neon-green);
+            box-shadow: 0 10px 30px rgba(57, 255, 20, 0.2);
+        }
+        
+        .tool-icon {
+            font-size: 3rem;
+            color: var(--neon-green);
+            margin-bottom: 1.5rem;
+        }
+        
+        .tool-name {
+            font-size: 1.5rem;
+            color: var(--accent);
+            margin-bottom: 1rem;
+        }
+        
+        .tool-description {
+            line-height: 1.6;
+            opacity: 0.9;
+            margin-bottom: 1.5rem;
+        }
+        
+        .tool-features {
+            list-style: none;
+            padding: 0;
+            margin: 0;
+        }
+        
+        .tool-features li {
+            padding-left: 1.5rem;
+            position: relative;
+            margin-bottom: 0.5rem;
+            opacity: 0.8;
+            font-size: 0.9rem;
+        }
+        
+        .tool-features li:before {
+            content: "▸";
+            position: absolute;
+            left: 0;
+            color: var(--neon-green);
+        }
+        
+        .tool-status {
+            display: inline-block;
+            padding: 0.3rem 0.8rem;
+            background: rgba(57, 255, 20, 0.1);
+            border: 1px solid rgba(57, 255, 20, 0.3);
+            border-radius: 4px;
+            font-size: 0.8rem;
+            color: var(--neon-green);
+            margin-top: 1rem;
+        }
+        
+        .coming-soon {
+            background: rgba(0, 191, 255, 0.1);
+            border-color: rgba(0, 191, 255, 0.3);
+            color: var(--network-accent);
+        }
+        
+        .beta-banner {
+            background: rgba(57, 255, 20, 0.1);
+            border: 1px solid rgba(57, 255, 20, 0.3);
+            padding: 1rem 1.5rem;
+            border-radius: 4px;
+            text-align: center;
+            margin-bottom: 2rem;
+        }
+        
+        .beta-banner p {
+            margin: 0;
+            color: var(--neon-green);
+        }
+    </style>
+</head>
+<body>
+    <canvas class="matrix-bg" id="matrixCanvas"></canvas>
+    
+    <nav class="nav-bar">
+        <div class="nav-container">
+            <a href="index.html" class="nav-logo">neural<span class="brackets">[</span>config<span class="brackets">]</span></a>
+            <div class="nav-links">
+                <a href="index.html" class="nav-link">home</a>
+                <a href="projects.html" class="nav-link">projects</a>
+                <a href="skills.html" class="nav-link">skills</a>
+                <a href="tools.html" class="nav-link active">tools</a>
+                <a href="https://github.com/neuralconfig" class="nav-link external">github</a>
+            </div>
+        </div>
+    </nav>
+
+    <div class="container">
+        <div class="tools-header">
+            <h1 class="tools-title">Automation Tools</h1>
+            <p class="tools-subtitle">
+                Powerful web-based tools designed to streamline network management and automation workflows. 
+                Built with enterprise-grade security and deployed on Google Cloud Platform.
+            </p>
+        </div>
+
+        <div class="beta-banner">
+            <p>🚀 Our tools collection is growing! Check back regularly for new additions.</p>
+        </div>
+
+        <div class="tools-grid">
+            <a href="https://szacl.neuralconfig.com" class="tool-card" target="_blank">
+                <div class="tool-icon">🔒</div>
+                <h2 class="tool-name">SZ-ACL</h2>
+                <p class="tool-description">
+                    Advanced Access Control List management for Ruckus SmartZone networks. 
+                    Create, update, and manage Layer 3 ACL policies through an intuitive web interface.
+                </p>
+                <ul class="tool-features">
+                    <li>Web-based ACL policy editor</li>
+                    <li>Bulk import/export via CSV</li>
+                    <li>Wildcard template support</li>
+                    <li>Firewall profile management</li>
+                    <li>Rate limiting configuration</li>
+                </ul>
+                <span class="tool-status">Live</span>
+            </a>
+
+            <div class="tool-card" style="opacity: 0.6; cursor: not-allowed;">
+                <div class="tool-icon">📊</div>
+                <h2 class="tool-name">Network Analyzer</h2>
+                <p class="tool-description">
+                    Real-time network traffic analysis and visualization tool. Monitor bandwidth usage, 
+                    identify bottlenecks, and optimize network performance.
+                </p>
+                <ul class="tool-features">
+                    <li>Live traffic monitoring</li>
+                    <li>Protocol analysis</li>
+                    <li>Performance metrics</li>
+                    <li>Historical trending</li>
+                </ul>
+                <span class="tool-status coming-soon">Coming Soon</span>
+            </div>
+
+            <div class="tool-card" style="opacity: 0.6; cursor: not-allowed;">
+                <div class="tool-icon">🛡️</div>
+                <h2 class="tool-name">Security Auditor</h2>
+                <p class="tool-description">
+                    Automated security assessment tool for network configurations. 
+                    Identify vulnerabilities and compliance issues across your infrastructure.
+                </p>
+                <ul class="tool-features">
+                    <li>Configuration scanning</li>
+                    <li>Vulnerability detection</li>
+                    <li>Compliance reporting</li>
+                    <li>Remediation guidance</li>
+                </ul>
+                <span class="tool-status coming-soon">Coming Soon</span>
+            </div>
+        </div>
+    </div>
+
+    <script src="matrix.js"></script>
+</body>
+</html>

--- a/wifi-test.html
+++ b/wifi-test.html
@@ -169,6 +169,7 @@
                 <a href="index.html" class="nav-link">home</a>
                 <a href="projects.html" class="nav-link">projects</a>
                 <a href="skills.html" class="nav-link">skills</a>
+                <a href="tools.html" class="nav-link">tools</a>
                 <a href="https://github.com/neuralconfig" class="nav-link external">github</a>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- Add new automation tools section to showcase web-based tools
- Update SZ-ACL project page with Google Cloud deployment details and link to live web app at szacl.neuralconfig.com
- Add tools navigation throughout the site for better discoverability

## Test plan
- [x] Navigate to tools.html and verify page displays correctly
- [x] Click on SZ-ACL tool card and verify it links to szacl.neuralconfig.com
- [x] Verify tools link appears in navigation on all pages
- [x] Click "Automation Tools" button on homepage and verify navigation
- [x] Check SZ-ACL project page for updated content about web deployment