### PR TITLE
Update homepage buttons and enhance skills page

### DIFF
--- a/index.html
+++ b/index.html
@@ -160,10 +160,10 @@
         </div>
         
         <div class="cta-buttons">
-            <a href="projects.html" class="cta-button primary">View Projects</a>
-            <a href="tools.html" class="cta-button">Automation Tools</a>
-            <a href="skills.html" class="cta-button">Technical Skills</a>
-            <a href="mailto:contact@neuralconfig.com" class="cta-button">Get In Touch</a>
+            <a href="projects.html" class="cta-button primary">Projects</a>
+            <a href="tools.html" class="cta-button">Tools</a>
+            <a href="skills.html" class="cta-button">Skills</a>
+            <a href="mailto:contact@neuralconfig.com" class="cta-button">Contact</a>
         </div>
     </div>
     </div>

--- a/skills.html
+++ b/skills.html
@@ -196,6 +196,7 @@
         <div class="terminal" style="margin-top: 3rem;">
             <div class="terminal-line"><span class="terminal-prompt">$</span> whoami</div>
             <div class="terminal-line" style="margin-left: 2rem;">Systems engineer passionate about AI, automation, and building intelligent solutions.</div>
+            <div class="terminal-line" style="margin-left: 2rem;">Deep expertise in enterprise networking, routing/switching protocols, and Wi-Fi design.</div>
             <div class="terminal-line" style="margin-left: 2rem;">Specializing in LLM integration, network security, and scalable system architecture.</div>
             <div class="terminal-line" style="margin-left: 2rem;">Focused on advancing practical AI applications and human-computer interaction.</div>
             <div class="terminal-line terminal-cursor"></div>
@@ -260,13 +261,15 @@
         <div class="about-section" style="margin-top: 3rem; padding: 2rem; background: rgba(5,5,5,0.5); border-radius: 4px;">
             <h2 style="color: var(--accent); margin-bottom: 1rem;">Philosophy & Approach</h2>
             <p style="margin-bottom: 1rem; line-height: 1.8;">
-                My technology journey spans from network security to AI integration, where I focus on 
-                building systems that bridge cutting-edge capabilities with practical business solutions.
+                My technology journey spans from enterprise networking and Wi-Fi architecture to AI integration, 
+                with extensive experience in routing/switching protocols, wireless design, and network security. 
+                I focus on building systems that bridge cutting-edge capabilities with practical business solutions.
             </p>
             <p style="margin-bottom: 1rem; line-height: 1.8;">
                 I believe in creating intelligent systems that augment human capabilities while remaining 
-                accessible, reliable, and beneficial. My experience from low-level network protocols to 
-                high-level AI orchestration provides a comprehensive perspective on system design.
+                accessible, reliable, and beneficial. My experience from low-level network protocols, RF engineering, 
+                and data center design to high-level AI orchestration provides a comprehensive perspective on 
+                system design across the entire technology stack.
             </p>
             <p style="line-height: 1.8;">
                 <strong style="color: var(--neon-green);">Focus:</strong> Developing AI systems that are powerful yet aligned with human values, 


### PR DESCRIPTION
## Summary
- Shortened homepage button text for improved desktop layout
- Enhanced skills page to highlight networking expertise

## Changes
- Homepage: Shortened button labels to \Projects\, \Tools\, \Skills\, \Contact\ for better single-line display on desktop
- Skills page: Added networking and Wi-Fi expertise to whoami section
- Philosophy section: Updated to emphasize comprehensive technology stack experience from RF engineering to AI

## Test plan
- [x] Verify homepage buttons display on single line on desktop browsers
- [x] Review updated skills page content for accuracy and flow