### PR TITLE
Fix auto-play sequence, network-first framing, project ordering

### DIFF
--- a/404.html
+++ b/404.html
@@ -133,7 +133,7 @@
     </main>
 
     <footer class="footer" role="contentinfo">
-        © 2025 NeuralConfig LLC | <a href="mailto:contact@neuralconfig.com">contact@neuralconfig.com</a>
+        © 2025-2026 NeuralConfig LLC | <a href="mailto:contact@neuralconfig.com">contact@neuralconfig.com</a>
     </footer>
     <script data-goatcounter="https://neuralconfig.goatcounter.com/count"
             async src="//gc.zgo.at/count.js"></script>

--- a/ap-reboot-manager.html
+++ b/ap-reboot-manager.html
@@ -426,7 +426,7 @@
     </main>
 
     <footer class="footer" role="contentinfo">
-        © 2025 NeuralConfig LLC | <a href="mailto:contact@neuralconfig.com" style="color: var(--accent); text-decoration: none;">contact@neuralconfig.com</a>
+        © 2025-2026 NeuralConfig LLC | <a href="mailto:contact@neuralconfig.com" style="color: var(--accent); text-decoration: none;">contact@neuralconfig.com</a>
     </footer>
 
     <script src="matrix.js" defer></script>

--- a/device-profiler.html
+++ b/device-profiler.html
@@ -281,7 +281,7 @@
     </main>
 
     <footer class="footer" role="contentinfo">
-        © 2025 NeuralConfig LLC | <a href="mailto:contact@neuralconfig.com">contact@neuralconfig.com</a>
+        © 2025-2026 NeuralConfig LLC | <a href="mailto:contact@neuralconfig.com">contact@neuralconfig.com</a>
     </footer>
     <script data-goatcounter="https://neuralconfig.goatcounter.com/count"
             async src="//gc.zgo.at/count.js"></script>

--- a/github-contributions.js
+++ b/github-contributions.js
@@ -104,7 +104,7 @@ async function renderContributionGraph() {
                 <h3>GitHub Contributions</h3>
             </div>
             <div class="contribution-graph-wrapper" style="background: #0a0a0a; padding: 1rem; border-radius: 4px;">
-                <a href="https://github.com/${GITHUB_USERNAME}" target="_blank" rel="noopener" style="display: block;">
+                <a href="https://github.com/neuralconfig" target="_blank" rel="noopener" style="display: block;">
                     ${graphSVG}
                 </a>
             </div>
@@ -120,7 +120,7 @@ async function renderContributionGraph() {
             <div style="padding: 1rem; text-align: center; background: #0a0a0a; border-radius: 4px; color: #888;">
                 <p style="margin-bottom: 0.5rem;">Contribution data not yet available.</p>
                 <p style="font-size: 0.85rem; margin-bottom: 1rem;">The GitHub Action will generate it soon.</p>
-                <a href="https://github.com/${GITHUB_USERNAME}" target="_blank" rel="noopener" style="color: var(--accent); text-decoration: underline;">
+                <a href="https://github.com/neuralconfig" target="_blank" rel="noopener" style="color: var(--accent); text-decoration: underline;">
                     View on GitHub →
                 </a>
             </div>

--- a/index.html
+++ b/index.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>NeuralConfig | AI Consulting & Software Development</title>
-    <meta name="description" content="AI consulting and software development services. Agentic AI, RAG systems, network automation. 20+ years infrastructure experience, Stanford ML, CISSP.">
+    <title>NeuralConfig | Enterprise AI Systems & Automation</title>
+    <meta name="description" content="Production AI systems for enterprise operations. Agentic tool calling, RAG architectures, Python SDKs. 12+ years enterprise architecture. Stanford ML, CISSP.">
     <meta name="keywords" content="AI consulting, AI software development, agentic AI, autonomous agents, RAG systems, LLM integration, network automation, CISSP">
     <meta name="author" content="NeuralConfig LLC">
     <meta name="robots" content="index, follow">
@@ -340,7 +340,7 @@
     </main>
 
     <footer class="footer" role="contentinfo">
-        © 2025 NeuralConfig LLC | <a href="mailto:contact@neuralconfig.com" style="color: var(--accent); text-decoration: none;">contact@neuralconfig.com</a>
+        © 2025-2026 NeuralConfig LLC | <a href="mailto:contact@neuralconfig.com" style="color: var(--accent); text-decoration: none;">contact@neuralconfig.com</a>
     </footer>
 
     <script src="matrix.js" defer></script>
@@ -446,9 +446,9 @@
                 prompt: 'root@neuralconfig:~#',
                 command: ' whoami',
                 output: [
-                    '<span class="output-highlight">Network Engineer × AI Developer</span>',
-                    'Bridging 20+ years of network infrastructure with modern AI systems',
-                    'Building production-ready intelligent automation',
+                    '<span class="output-highlight">Solutions Architect × AI Builder</span>',
+                    '12+ years enterprise architecture | Pre-sales technical leadership',
+                    'Building production AI systems for enterprise operations',
                     '',
                     'Most AI devs don\'t understand networks. Most network engineers don\'t build AI.',
                     'I do both.'
@@ -459,41 +459,11 @@
                 command: ' tree -L 1 ~/projects --dirsfirst',
                 output: [
                     '<span class="output-highlight">~/projects</span>',
-                    '├── <span class="output-success">ruckus-ztp/</span>         # AI-powered network provisioning',
-                    '├── <span class="output-success">osticket-agent/</span>     # Autonomous support agent',
-                    '├── <span class="output-info">r1-api/</span>             # RUCKUS One Python SDK',
-                    '├── <span class="output-info">survival-rag/</span>       # RAG knowledge system',
-                    '├── <span class="output-info">device-profiler/</span>    # IoT device classification',
-                    '└── <span class="output-dim">sz-acl/</span>             # ACL management tool'
-                ]
-            },
-            {
-                prompt: 'root@neuralconfig:~#',
-                command: '# click or press any key to interact',
-                output: []
-            },
-            {
-                prompt: 'root@neuralconfig:~#',
-                command: ' cat services.yaml',
-                output: [
-                    '<span class="output-highlight">Core Services:</span>',
-                    '  <span class="output-success">✓</span> AI System Architecture & Consulting',
-                    '  <span class="output-success">✓</span> Network Automation & Zero-Touch Provisioning',
-                    '  <span class="output-success">✓</span> Agentic AI Development',
-                    '  <span class="output-success">✓</span> RAG Implementation & LLM Integration',
-                    '  <span class="output-success">✓</span> Open Source Network Management Tools'
-                ]
-            },
-            {
-                prompt: 'root@neuralconfig:~#',
-                command: ' curl -s localhost:8080/api/profile | jq \'.skills[]\'',
-                output: [
-                    '"Agentic AI System Architecture"',
-                    '"LLM Integration (Claude, GPT, Gemini)"',
-                    '"RAG & Vector Database Implementation"',
-                    '"Network Automation (Python/NETCONF)"',
-                    '"Zero-Touch Provisioning"',
-                    '"CISSP | Zero Trust Security"'
+                    '├── <span class="output-success">jira-analyzer/</span>        # AI feature request pipeline (19 modules)',
+                    '├── <span class="output-success">osticket-agent/</span>       # Autonomous AI agent (Claude Haiku)',
+                    '├── <span class="output-success">ruckus-ztp/</span>           # AI-powered network provisioning',
+                    '├── <span class="output-info">r1-api/</span>               # RUCKUS One Python SDK',
+                    '└── <span class="output-info">device-profiler/</span>      # IoT device classification'
                 ]
             },
             {
@@ -509,127 +479,34 @@
             },
             {
                 prompt: 'root@neuralconfig:~#',
-                command: ' git log --oneline -5',
+                command: '# click or press any key to interact',
+                output: []
+            },
+            {
+                prompt: 'root@neuralconfig:~#',
+                command: ' curl -s localhost:8080/api/profile | jq \'.skills[]\'',
                 output: [
-                    '<span class="output-warning">eba9d52</span> feat: update positioning to Principal Systems Engineer',
-                    '<span class="output-warning">01977cc</span> feat: add r1-api project and enhance terminal',
-                    '<span class="output-warning">e9314e9</span> feat: add ruckus-ztp and enhance AI agent emphasis',
-                    '<span class="output-warning">d11c795</span> feat: add RUCKUS One Python SDK',
-                    '<span class="output-warning">41e41cb</span> feat: osticket autonomous AI agent'
+                    '"Agentic AI System Architecture"',
+                    '"LLM Integration (Claude, GPT, Gemini)"',
+                    '"RAG & Vector Database Implementation"',
+                    '"Network Automation (Python/NETCONF)"',
+                    '"Zero-Touch Provisioning"',
+                    '"CISSP | Zero Trust Security"'
                 ]
             },
             {
                 prompt: 'root@neuralconfig:~#',
-                command: ' systemctl status automation-stack',
+                command: ' python -m jira_analyzer --stages',
                 output: [
-                    '<span class="output-success">●</span> automation-stack.service - Network Automation Platform',
-                    '   Loaded: loaded (/etc/systemd/system/automation.service; enabled)',
-                    '   Active: <span class="output-success">active (running)</span> since Jan 2025',
-                    '   Status: "Processing automation workflows"',
-                    '   Memory: 512.0M | CPU: 2.5%'
-                ]
-            },
-            {
-                prompt: 'root@neuralconfig:~#',
-                command: ' docker ps --format "table {{.Names}}\\t{{.Status}}"',
-                output: [
-                    'NAMES                STATUS',
-                    'ai-agent             Up 45 days',
-                    'vector-database      Up 45 days',
-                    'api-gateway          Up 45 days',
-                    'monitoring           Up 45 days'
-                ]
-            },
-            {
-                prompt: 'root@neuralconfig:~#',
-                command: ' curl https://neuralconfig.com/tools/ | jq .available',
-                output: [
-                    '{',
-                    '  "fastiron-navigator": "live",',
-                    '  "sz-acl": "maintenance"',
-                    '}'
-                ]
-            },
-            {
-                prompt: 'root@neuralconfig:~#',
-                command: ' cat ruckus-ztp/agent.py | head -20',
-                output: [
-                    '<span class="output-dim"># AI Agent for RUCKUS Zero-Touch Provisioning</span>',
-                    '<span class="output-dim">from anthropic import Anthropic</span>',
-                    '<span class="output-dim">import json</span>',
+                    '<span class="output-highlight">Pipeline Stages:</span>',
                     '',
-                    '<span class="output-dim">def configure_device(device_info):</span>',
-                    '<span class="output-dim">    """Use AI to generate optimal configuration"""</span>',
-                    '<span class="output-dim">    client = Anthropic()</span>',
-                    '<span class="output-dim">    response = client.messages.create(</span>',
-                    '<span class="output-dim">        model="claude-3-5-sonnet-20241022",</span>',
-                    '<span class="output-dim">        tools=[network_config_tool],</span>',
-                    '<span class="output-dim">        messages=[{</span>',
-                    '<span class="output-dim">            "role": "user",</span>',
-                    '<span class="output-dim">            "content": f"Configure {device_info}"</span>',
-                    '<span class="output-dim">        }]</span>',
-                    '<span class="output-dim">    )</span>',
+                    '  <span class="output-success">1.</span> Jira Extract        → JQL queries, feature request filtering',
+                    '  <span class="output-success">2.</span> SFDC Revenue        → Account matching, revenue enrichment',
+                    '  <span class="output-success">3.</span> Vertical Rating     → Qwen3-30B-A3B scoring per industry',
+                    '  <span class="output-success">4.</span> Priority Ranking    → Revenue-weighted cross-vertical aggregation',
+                    '  <span class="output-success">5.</span> Confluence Publish  → Auto-generated ranked reports',
                     '',
-                    '<span class="output-success">✓ Autonomous AI configuration engine</span>'
-                ]
-            },
-            {
-                prompt: 'root@neuralconfig:~#',
-                command: ' kubectl get pods -n production',
-                output: [
-                    'NAME                          READY   STATUS    RESTARTS   AGE',
-                    'ai-agent-7d9f8c4b5-x9k2m      1/1     Running   0          15d',
-                    'vector-db-6c8d7f9b4-p7q3n     1/1     Running   0          15d',
-                    'api-gateway-5b7c8d9f2-m4r5t   1/1     Running   0          15d',
-                    'rag-service-8f9d2c3b7-k6p8w   1/1     Running   0          12d',
-                    '',
-                    '<span class="output-success">All systems operational</span>'
-                ]
-            },
-            {
-                prompt: 'root@neuralconfig:~#',
-                command: ' tail -f /var/log/ai-agent/activity.log',
-                output: [
-                    '<span class="output-dim">2025-01-15 14:23:45</span> <span class="output-success">[INFO]</span> Processing support ticket #4521',
-                    '<span class="output-dim">2025-01-15 14:23:46</span> <span class="output-success">[INFO]</span> RAG context retrieved: 15 documents',
-                    '<span class="output-dim">2025-01-15 14:23:47</span> <span class="output-success">[INFO]</span> Agent decision: route to network team',
-                    '<span class="output-dim">2025-01-15 14:23:48</span> <span class="output-success">[INFO]</span> Ticket categorized: L3 routing issue',
-                    '<span class="output-dim">2025-01-15 14:23:49</span> <span class="output-success">[INFO]</span> Response generated and validated',
-                    '',
-                    '<span class="output-dim">^C</span>'
-                ]
-            },
-            {
-                prompt: 'root@neuralconfig:~#',
-                command: ' terraform plan -out=infrastructure.tfplan',
-                output: [
-                    '<span class="output-info">Terraform v1.6.0</span>',
-                    '<span class="output-dim">Refreshing state... [36s elapsed]</span>',
-                    '',
-                    '<span class="output-success">Plan: 3 to add, 0 to change, 0 to destroy.</span>',
-                    '',
-                    '  + google_cloud_function.ai_agent',
-                    '  + google_cloud_run.api_service',
-                    '  + google_compute_instance.monitoring',
-                    '',
-                    '<span class="output-dim">Saved the plan to: infrastructure.tfplan</span>'
-                ]
-            },
-            {
-                prompt: 'root@neuralconfig:~#',
-                command: ' cat osticket-agent/stats.json | jq .',
-                output: [
-                    '{',
-                    '  "tickets_processed": <span class="output-success">2,847</span>,',
-                    '  "avg_response_time": "<span class="output-success">45s</span>",',
-                    '  "accuracy_rate": "<span class="output-success">94.3%</span>",',
-                    '  "categories": {',
-                    '    "network": 1203,',
-                    '    "security": 892,',
-                    '    "application": 752',
-                    '  },',
-                    '  "status": "<span class="output-success">operational</span>"',
-                    '}'
+                    '<span class="output-dim">19 modules | All inference runs locally via Ollama</span>'
                 ]
             },
             {
@@ -645,6 +522,18 @@
                     '<span class="output-success">✓</span> Explicit approval workflows for production changes',
                     '',
                     '<span class="output-dim">"Reliable AI is responsible AI"</span>'
+                ]
+            },
+            {
+                prompt: 'root@neuralconfig:~#',
+                command: ' cat services.yaml',
+                output: [
+                    '<span class="output-highlight">Core Services:</span>',
+                    '  <span class="output-success">✓</span> AI System Architecture & Consulting',
+                    '  <span class="output-success">✓</span> Network Automation & Zero-Touch Provisioning',
+                    '  <span class="output-success">✓</span> Agentic AI Development',
+                    '  <span class="output-success">✓</span> RAG Implementation & LLM Integration',
+                    '  <span class="output-success">✓</span> Open Source Network Management Tools'
                 ]
             },
         ];
@@ -1802,9 +1691,9 @@
 
                     const allProjects = {
                         ai: [
-                            '✓ <span class="output-success">ruckus-ztp</span>        [AI-AGENT] [ACTIVE]',
-                            '✓ <span class="output-success">osticket-agent</span>   [AI-AGENT] [DEPLOYED]',
-                            '✓ <span class="output-success">survival-rag</span>     [AI-RAG] [ACTIVE]'
+                            '✓ <span class="output-success">jira-analyzer</span>    [AI-PIPELINE] [ACTIVE]',
+                            '✓ <span class="output-success">osticket-agent</span>   [CLAUDE API] [DEPLOYED]',
+                            '✓ <span class="output-success">ruckus-ztp</span>        [AI-AGENT] [ACTIVE]'
                         ],
                         network: [
                             '✓ <span class="output-info">r1-api</span>           [SDK] [LIVE]',
@@ -1893,10 +1782,10 @@
 
                 case 'whoami':
                     return [
-                        '<span class="output-highlight">AI & Infrastructure Architect</span>',
-                        'Specializing in AI-driven network automation',
-                        '20+ years network infrastructure experience',
-                        'Building intelligent systems at the intersection of AI and networking'
+                        '<span class="output-highlight">Solutions Architect × AI Builder</span>',
+                        '12+ years designing enterprise architectures at global scale',
+                        'Networking, wireless, security | Linux, virtualization, storage',
+                        'Building production AI systems that solve real infrastructure problems'
                     ];
 
                 case 'date':

--- a/jira-analyzer.html
+++ b/jira-analyzer.html
@@ -92,14 +92,13 @@
             <p class="story-text">
                 An <strong>AI-powered analysis pipeline</strong> that transforms raw Jira feature requests into
                 prioritized, revenue-enriched intelligence. The system extracts issues from Jira, enriches them
-                with Salesforce revenue data, uses local LLMs to rate vertical-specific relevance, detects
-                duplicates through multi-stage fuzzy matching, and publishes ranked reports to Confluence.
+                with Salesforce revenue data, uses local LLMs to rate vertical-specific relevance, ranks by
+                revenue-weighted priority, and publishes ranked reports to Confluence.
             </p>
             <p class="story-text">
                 <strong>Key Innovation:</strong> By running all AI inference through local Ollama models, the pipeline
                 keeps sensitive customer data and feature request details entirely on-premises—no data leaves the
-                network. The 3-stage duplicate detection combines TF-IDF (term frequency-inverse document frequency) similarity, sentence-transformer embeddings (numerical representations of meaning),
-                and LLM-based semantic comparison to catch duplicates that keyword matching alone would miss.
+                network. The repository also includes a standalone deduplication utility that combines TF-IDF similarity, sentence-transformer embeddings, and LLM-based semantic comparison to identify duplicate feature requests independently.
             </p>
             <p class="story-text">
                 The pipeline produces priority-ranked feature requests weighted by customer revenue impact, enabling
@@ -161,16 +160,6 @@
                         <text class="diagram-subtitle" x="75" y="52" text-anchor="middle">Cross-Vertical</text>
                     </g>
 
-                    <!-- Branch down from Vertical Rating to Duplicate Detection -->
-                    <path class="diagram-arrow" d="M 485 85 L 485 130" marker-end="url(#arrow-jira)"/>
-
-                    <g transform="translate(410, 140)">
-                        <rect class="diagram-node-verify" x="0" y="0" width="150" height="60" rx="4"/>
-                        <text class="diagram-title" x="75" y="22" text-anchor="middle" style="fill: #4ec9b0;">Duplicate Detection</text>
-                        <text class="diagram-subtitle" x="75" y="38" text-anchor="middle">TF-IDF + Embeddings</text>
-                        <text class="diagram-subtitle" x="75" y="52" text-anchor="middle">LLM Verification</text>
-                    </g>
-
                     <!-- Branch down from Priority Ranking to Confluence Reports -->
                     <path class="diagram-arrow" d="M 685 85 L 685 130" marker-end="url(#arrow-jira)"/>
 
@@ -201,7 +190,7 @@
                 </div>
                 <div class="feature-card">
                     <h3>Duplicate Detection</h3>
-                    <p>3-stage dedup pipeline: TF-IDF similarity, sentence-transformer embeddings, and LLM verification</p>
+                    <p>Standalone companion utility: TF-IDF similarity, sentence-transformer embeddings, and LLM verification for independent dedup analysis</p>
                 </div>
                 <div class="feature-card">
                     <h3>Priority Ranking</h3>
@@ -283,7 +272,7 @@
     </main>
 
     <footer class="footer" role="contentinfo">
-        &copy; 2025 NeuralConfig LLC | <a href="mailto:contact@neuralconfig.com">contact@neuralconfig.com</a>
+        &copy; 2025-2026 NeuralConfig LLC | <a href="mailto:contact@neuralconfig.com">contact@neuralconfig.com</a>
     </footer>
     <script data-goatcounter="https://neuralconfig.goatcounter.com/count"
             async src="//gc.zgo.at/count.js"></script>

--- a/openrouter-chat-app.html
+++ b/openrouter-chat-app.html
@@ -174,7 +174,7 @@
     </main>
 
     <footer class="footer" role="contentinfo">
-        © 2025 NeuralConfig LLC | <a href="mailto:contact@neuralconfig.com">contact@neuralconfig.com</a>
+        © 2025-2026 NeuralConfig LLC | <a href="mailto:contact@neuralconfig.com">contact@neuralconfig.com</a>
     </footer>
     <script data-goatcounter="https://neuralconfig.goatcounter.com/count"
             async src="//gc.zgo.at/count.js"></script>

--- a/osticket-agent.html
+++ b/osticket-agent.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>osTicket AI Agent - Autonomous Support Automation | NeuralConfig</title>
-    <meta name="description" content="Agentic AI system for osTicket that autonomously manages support tickets using NLP, tool-calling, and network infrastructure interaction.">
+    <meta name="description" content="Autonomous IT operations agent built with Claude Haiku. LLM tool calling for enterprise network switch management with structured audit trails.">
     <link rel="canonical" href="https://neuralconfig.com/osticket-agent.html">
     <meta name="robots" content="index, follow">
 
@@ -84,6 +84,9 @@
                 <div class="project-meta-item">
                     <span class="brackets">[</span>License<span class="brackets">]</span>: MIT
                 </div>
+                <div class="project-meta-item">
+                    <span class="brackets">[</span>LLM<span class="brackets">]</span>: Claude Haiku
+                </div>
             </div>
         </div>
 
@@ -91,15 +94,15 @@
             <h2 class="section-heading">Overview</h2>
             <p class="story-text">
                 An <strong>Agentic AI system</strong> that autonomously manages support tickets in osTicket by combining
-                natural language understanding with intelligent tool-calling capabilities. This cutting-edge agent doesn't
+                natural language understanding with intelligent tool-calling capabilities. The agent doesn't
                 just categorize tickets—it actively interacts with network infrastructure, queries databases, and executes
                 commands to resolve issues without human intervention.
             </p>
             <p class="story-text">
-                <strong>Key Innovation:</strong> The AI agent uses advanced tool orchestration to analyze support tickets,
+                <strong>Key Innovation:</strong> The agent uses Claude Haiku's tool-calling capabilities to analyze support tickets,
                 then autonomously connects to network switches, servers, and other infrastructure to diagnose and resolve
                 issues. It can execute SSH commands, query APIs, analyze logs, and implement fixes—all while maintaining
-                a conversational interface with the ticket submitter.
+                a conversational interface with the ticket submitter. Claude was chosen for production deployment due to reliable tool calling, consistent JSON output, and API ergonomics.
             </p>
         </section>
 
@@ -134,9 +137,9 @@
 
                     <g transform="translate(200, 20)">
                         <rect class="diagram-node" x="0" y="0" width="140" height="60" rx="4"/>
-                        <text class="diagram-title" x="70" y="22" text-anchor="middle">AI Agent</text>
-                        <text class="diagram-subtitle" x="70" y="38" text-anchor="middle">LLM Analysis</text>
-                        <text class="diagram-subtitle" x="70" y="52" text-anchor="middle">Intent Extract</text>
+                        <text class="diagram-title" x="70" y="22" text-anchor="middle">Claude Haiku</text>
+                        <text class="diagram-subtitle" x="70" y="38" text-anchor="middle">Intent Analysis</text>
+                        <text class="diagram-subtitle" x="70" y="52" text-anchor="middle">Tool Calling</text>
                     </g>
 
                     <path class="diagram-arrow" d="M 345 50 L 380 50" marker-end="url(#arrow)"/>
@@ -183,6 +186,15 @@
                         <rect class="diagram-node-verify" x="0" y="0" width="150" height="40" rx="4"/>
                         <text class="diagram-title" x="75" y="26" text-anchor="middle" style="fill: #4ec9b0;">Autonomous Verify</text>
                     </g>
+
+                    <!-- Audit Trail branch from Action Execution -->
+                    <path class="diagram-arrow" d="M 422 180 L 422 210" marker-end="url(#arrow)"/>
+
+                    <g transform="translate(350, 220)">
+                        <rect class="diagram-node-verify" x="0" y="0" width="145" height="40" rx="4"/>
+                        <text class="diagram-title" x="72" y="16" text-anchor="middle" style="fill: #4ec9b0;">Audit Trail</text>
+                        <text class="diagram-subtitle" x="72" y="32" text-anchor="middle">Structured Logging</text>
+                    </g>
                 </svg>
             </div>
         </section>
@@ -216,7 +228,7 @@
                 understanding with real-world tool execution. Core technical innovations:
             </p>
             <ul class="feature-list">
-                <li><strong>LLM-Powered Decision Engine:</strong> Advanced language model that analyzes tickets and determines appropriate tool sequences</li>
+                <li><strong>LLM-Powered Decision Engine:</strong> Claude Haiku that analyzes tickets and determines appropriate tool sequences</li>
                 <li><strong>Tool Orchestration Framework:</strong> Intelligent selection and execution of tools based on ticket context</li>
                 <li><strong>Network Device Integration:</strong> SSH/API connectors for direct interaction with switches, routers, and servers</li>
                 <li><strong>Autonomous Problem Solving:</strong> Agent chains together multiple tools to diagnose and resolve complex issues</li>
@@ -234,9 +246,9 @@
         <div class="ai-highlight">
             <h3>Agentic AI Innovation</h3>
             <p>
-                This project exemplifies the cutting edge of Agentic AI in 2025—autonomous agents that don't just
-                understand and categorize, but actively interact with physical infrastructure to solve problems.
-                By combining LLMs with tool-calling capabilities, the agent bridges the gap between understanding
+                This project demonstrates production-grade agentic AI — autonomous systems that execute real
+                changes on enterprise infrastructure with full audit accountability.
+                By combining Claude with tool-calling capabilities, the agent bridges the gap between understanding
                 natural language and executing real-world actions on network devices.
             </p>
         </div>
@@ -245,8 +257,8 @@
             <h2 class="section-heading">Technology Stack</h2>
             <div class="tech-stack">
                 <span class="tech-badge ai">Python 3.11+</span>
-                <span class="tech-badge ai">Agentic AI Framework</span>
-                <span class="tech-badge ai">LangChain</span>
+                <span class="tech-badge ai">Claude API</span>
+                <span class="tech-badge ai">Anthropic SDK</span>
                 <span class="tech-badge ai">Tool Calling</span>
                 <span class="tech-badge network">SSH/Paramiko</span>
                 <span class="tech-badge ai">FastAPI</span>
@@ -257,14 +269,14 @@
         <section class="section">
             <h2 class="section-heading">Enterprise Impact</h2>
             <p class="story-text">
-                Revolutionary capabilities enabled by Agentic AI:
+                Production capabilities:
             </p>
             <ul class="feature-list">
                 <li><strong>Autonomous Resolution:</strong> AI agent resolves issues without human intervention</li>
                 <li><strong>Infrastructure Integration:</strong> Direct interaction with network devices and servers</li>
                 <li><strong>Intelligent Tool Use:</strong> Agent selects and executes appropriate tools based on context</li>
                 <li><strong>24/7 Operations:</strong> Continuous autonomous support without human availability constraints</li>
-                <li><strong>Future-Ready:</strong> Positioned at the forefront of AI-driven IT operations</li>
+                <li><strong>Extensible Architecture:</strong> New tool integrations added without modifying the core agent loop</li>
             </ul>
         </section>
 
@@ -276,7 +288,7 @@
     </main>
 
     <footer class="footer" role="contentinfo">
-        © 2025 NeuralConfig LLC | <a href="mailto:contact@neuralconfig.com">contact@neuralconfig.com</a>
+        © 2025-2026 NeuralConfig LLC | <a href="mailto:contact@neuralconfig.com">contact@neuralconfig.com</a>
     </footer>
     <script data-goatcounter="https://neuralconfig.goatcounter.com/count"
             async src="//gc.zgo.at/count.js"></script>

--- a/pflogs.html
+++ b/pflogs.html
@@ -260,7 +260,7 @@
     </main>
 
     <footer class="footer" role="contentinfo">
-        © 2025 NeuralConfig LLC | <a href="mailto:contact@neuralconfig.com">contact@neuralconfig.com</a>
+        © 2025-2026 NeuralConfig LLC | <a href="mailto:contact@neuralconfig.com">contact@neuralconfig.com</a>
     </footer>
     <script data-goatcounter="https://neuralconfig.goatcounter.com/count"
             async src="//gc.zgo.at/count.js"></script>

--- a/projects.html
+++ b/projects.html
@@ -273,38 +273,6 @@
                 </div>
             </a>
 
-            <!-- AI Projects -->
-            <a href="openrouter-chat-app.html" class="project-card ai-project">
-                <div class="project-header">
-                    <h3>openrouter-chat-app</h3>
-                </div>
-                <p class="project-description">Simple yet powerful AI chat interface leveraging OpenRouter's API to access multiple LLM providers through a single endpoint.</p>
-                <div class="project-tech">
-                    <span class="tech-tag" style="background: var(--accent-ai);">LLM Integration</span>
-                    <span class="tech-tag" style="background: #0080ff;">API Design</span>
-                </div>
-                <div class="tech-badges">
-                    <span class="tech-badge badge-python">Python</span>
-                    <span class="tech-badge badge-api">OpenRouter</span>
-                </div>
-            </a>
-
-            <a href="survival-rag.html" class="project-card ai-project">
-                <div class="project-header">
-                    <h3>survival-rag</h3>
-                </div>
-                <p class="project-description">Retrieval-Augmented Generation system for survival knowledge, demonstrating practical RAG implementation and vector database integration.</p>
-                <div class="project-tech">
-                    <span class="tech-tag" style="background: var(--accent-ai);">RAG</span>
-                    <span class="tech-tag" style="background: #0080ff;">Vector DB</span>
-                </div>
-                <div class="tech-badges">
-                    <span class="tech-badge badge-python">Python</span>
-                    <span class="tech-badge badge-ai">LangChain</span>
-                    <span class="tech-badge badge-api">Pinecone</span>
-                </div>
-            </a>
-
             <!-- Device Profiling & Security -->
             <a href="device-profiler.html" class="project-card network-project security-project automation-project">
                 <div class="project-header">
@@ -413,6 +381,38 @@
                     <span class="tech-badge badge-network">RUCKUS One</span>
                 </div>
             </a>
+
+            <!-- AI Projects -->
+            <a href="openrouter-chat-app.html" class="project-card ai-project">
+                <div class="project-header">
+                    <h3>openrouter-chat-app</h3>
+                </div>
+                <p class="project-description">Simple yet powerful AI chat interface leveraging OpenRouter's API to access multiple LLM providers through a single endpoint.</p>
+                <div class="project-tech">
+                    <span class="tech-tag" style="background: var(--accent-ai);">LLM Integration</span>
+                    <span class="tech-tag" style="background: #0080ff;">API Design</span>
+                </div>
+                <div class="tech-badges">
+                    <span class="tech-badge badge-python">Python</span>
+                    <span class="tech-badge badge-api">OpenRouter</span>
+                </div>
+            </a>
+
+            <a href="survival-rag.html" class="project-card ai-project">
+                <div class="project-header">
+                    <h3>survival-rag</h3>
+                </div>
+                <p class="project-description">Retrieval-Augmented Generation system for survival knowledge, demonstrating practical RAG implementation and vector database integration.</p>
+                <div class="project-tech">
+                    <span class="tech-tag" style="background: var(--accent-ai);">RAG</span>
+                    <span class="tech-tag" style="background: #0080ff;">Vector DB</span>
+                </div>
+                <div class="tech-badges">
+                    <span class="tech-badge badge-python">Python</span>
+                    <span class="tech-badge badge-ai">LangChain</span>
+                    <span class="tech-badge badge-api">Pinecone</span>
+                </div>
+            </a>
         </div>
     </div>
 
@@ -470,7 +470,7 @@
     </main>
 
     <footer class="footer" role="contentinfo">
-        © 2025 NeuralConfig LLC | <a href="mailto:contact@neuralconfig.com">contact@neuralconfig.com</a>
+        © 2025-2026 NeuralConfig LLC | <a href="mailto:contact@neuralconfig.com">contact@neuralconfig.com</a>
     </footer>
     <script data-goatcounter="https://neuralconfig.goatcounter.com/count"
             async src="//gc.zgo.at/count.js"></script>

--- a/r1-api.html
+++ b/r1-api.html
@@ -507,7 +507,7 @@ venues = client.venues.list()<br>
     </main>
 
     <footer class="footer" role="contentinfo">
-        © 2025 NeuralConfig LLC | <a href="mailto:contact@neuralconfig.com" style="color: var(--accent); text-decoration: none;">contact@neuralconfig.com</a>
+        © 2025-2026 NeuralConfig LLC | <a href="mailto:contact@neuralconfig.com" style="color: var(--accent); text-decoration: none;">contact@neuralconfig.com</a>
     </footer>
     <script data-goatcounter="https://neuralconfig.goatcounter.com/count"
             async src="//gc.zgo.at/count.js"></script>

--- a/ruckus-ztp.html
+++ b/ruckus-ztp.html
@@ -91,7 +91,7 @@
             <h2 class="section-heading">Overview</h2>
             <p class="story-text">
                 An <strong>Agentic AI system</strong> that autonomously manages RUCKUS ICX network infrastructure through
-                Zero-Touch Provisioning (ZTP). This cutting-edge project showcases the power of AI agents with tool-calling
+                Zero-Touch Provisioning (ZTP). This project showcases the power of AI agents with tool-calling
                 capabilities to interact with physical network devices, make intelligent decisions, and execute complex
                 network operations without human intervention.
             </p>
@@ -184,7 +184,7 @@
         <section class="section">
             <h2 class="section-heading">Enterprise Value</h2>
             <p class="story-text">
-                Ruckus ZTP demonstrates cutting-edge expertise in:
+                Ruckus ZTP demonstrates production expertise in:
             </p>
             <ul class="feature-list">
                 <li><strong>Agentic AI Systems:</strong> Building autonomous agents that interact with physical infrastructure</li>
@@ -205,7 +205,7 @@
     </main>
 
     <footer class="footer" role="contentinfo">
-        © 2025 NeuralConfig LLC | <a href="mailto:contact@neuralconfig.com">contact@neuralconfig.com</a>
+        © 2025-2026 NeuralConfig LLC | <a href="mailto:contact@neuralconfig.com">contact@neuralconfig.com</a>
     </footer>
     <script data-goatcounter="https://neuralconfig.goatcounter.com/count"
             async src="//gc.zgo.at/count.js"></script>

--- a/skills.html
+++ b/skills.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>About - AI Systems Engineer & Network Architect | NeuralConfig</title>
-    <meta name="description" content="AI Systems Engineer with 20+ years network infrastructure experience. Stanford ML, CISSP certified. Building agentic AI systems and network automation.">
+    <title>About - AI Systems Engineer & Enterprise Architect | NeuralConfig</title>
+    <meta name="description" content="AI Systems Engineer with 12+ years enterprise architecture experience. Networking, Linux, virtualization, Kubernetes, cloud security. Stanford ML, CISSP certified.">
     <link rel="canonical" href="https://neuralconfig.com/skills.html">
     <meta name="robots" content="index, follow">
 
@@ -12,7 +12,7 @@
     <meta property="og:type" content="profile">
     <meta property="og:url" content="https://neuralconfig.com/skills.html">
     <meta property="og:title" content="About - AI Systems Engineer | NeuralConfig">
-    <meta property="og:description" content="AI Systems Engineer with 20+ years network infrastructure experience. Stanford ML, CISSP certified.">
+    <meta property="og:description" content="AI Systems Engineer with 12+ years enterprise architecture experience. Stanford ML, CISSP certified.">
     <meta property="og:image" content="https://neuralconfig.com/images/og-about.jpg">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
@@ -22,7 +22,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:site" content="@neuralconfig">
     <meta name="twitter:title" content="About - AI Systems Engineer | NeuralConfig">
-    <meta name="twitter:description" content="AI Systems Engineer with 20+ years network infrastructure experience. Stanford ML, CISSP certified.">
+    <meta name="twitter:description" content="AI Systems Engineer with 12+ years enterprise architecture experience. Stanford ML, CISSP certified.">
     <meta name="twitter:image" content="https://neuralconfig.com/images/og-about.jpg">
 
     <link rel="stylesheet" href="styles.css">
@@ -185,12 +185,11 @@
         <div class="story-section">
             <h2>My Story</h2>
             <p class="story-text">
-                For over 20 years, I've built and operated enterprise network infrastructure—from routing protocols and wireless architectures
-                to zero-trust security. But I always felt there was more we could do with automation.
+                For over 12 years, I've built and operated enterprise network infrastructure — routing protocols, wireless architectures, and zero-trust security — while also working across Linux, storage, and virtualization. As a pre-sales Solutions Architect, I translate technical complexity into business outcomes. But I always felt there was more we could do with automation.
             </p>
             <p class="story-text">
                 Then AI happened. Not the hype, but the real capabilities of LLMs and agentic systems. I saw an opportunity to bridge two worlds:
-                the deep infrastructure knowledge most AI developers don't have, and the modern AI capabilities most network engineers haven't explored.
+                the deep infrastructure knowledge most AI developers don't have, and the modern AI capabilities most infrastructure engineers haven't explored.
             </p>
         </div>
 
@@ -200,7 +199,7 @@
                 <div class="timeline-marker">01</div>
                 <div class="timeline-content">
                     <h3>The Foundation: Network Infrastructure</h3>
-                    <p>I began my career building enterprise networks across many verticals. Over two decades, I learned that production systems require more than technical specifications—they demand reliability, security, and operational excellence. I earned my CISSP, CCNP, and multiple wireless certifications while specializing in RUCKUS wireless architecture and zero-trust security implementations.</p>
+                    <p>I began my career building enterprise networks across many verticals. Over 12 years in pre-sales, I learned that production systems require more than technical specifications — they demand reliability, security, and operational excellence. I earned my CISSP, CCNP, KCNA, and multiple wireless certifications while specializing in RUCKUS wireless architecture and zero-trust security implementations.</p>
                 </div>
             </div>
 
@@ -251,7 +250,7 @@
             </div>
 
             <div class="tech-category">
-                <h3 class="tech-category-title">Network & Security</h3>
+                <h3 class="tech-category-title">Infrastructure & Security</h3>
                 <div class="tech-badges">
                     <span class="tech-badge network">CISSP</span>
                     <span class="tech-badge network">Zero Trust</span>
@@ -261,6 +260,9 @@
                     <span class="tech-badge network">Network Automation</span>
                     <span class="tech-badge network">ZTP</span>
                     <span class="tech-badge network">Protocol Analysis</span>
+                    <span class="tech-badge network">Linux</span>
+                    <span class="tech-badge network">Virtualization</span>
+                    <span class="tech-badge network">Storage</span>
                 </div>
             </div>
 
@@ -336,7 +338,7 @@
     </main>
 
     <footer class="footer" role="contentinfo">
-        © 2025 NeuralConfig LLC | <a href="mailto:contact@neuralconfig.com">contact@neuralconfig.com</a>
+        © 2025-2026 NeuralConfig LLC | <a href="mailto:contact@neuralconfig.com">contact@neuralconfig.com</a>
     </footer>
     <script data-goatcounter="https://neuralconfig.goatcounter.com/count"
             async src="//gc.zgo.at/count.js"></script>

--- a/styles.css
+++ b/styles.css
@@ -403,13 +403,23 @@ a:hover {
 }
 
 .section {
-    margin-bottom: var(--space-xl);
+    margin-bottom: var(--space-2xl);
 }
 
 .section h2 {
     color: var(--accent-secondary);
-    margin-bottom: var(--space-md);
+    margin-bottom: var(--space-lg);
     font-size: 1.5rem;
+}
+
+.story-text {
+    margin-bottom: var(--space-md);
+    line-height: 1.8;
+}
+
+.feature-list li {
+    margin-bottom: var(--space-sm);
+    line-height: 1.7;
 }
 
 .feature-grid {

--- a/survival-rag.html
+++ b/survival-rag.html
@@ -257,7 +257,7 @@
     </main>
 
     <footer class="footer" role="contentinfo">
-        © 2025 NeuralConfig LLC | <a href="mailto:contact@neuralconfig.com">contact@neuralconfig.com</a>
+        © 2025-2026 NeuralConfig LLC | <a href="mailto:contact@neuralconfig.com">contact@neuralconfig.com</a>
     </footer>
     <script data-goatcounter="https://neuralconfig.goatcounter.com/count"
             async src="//gc.zgo.at/count.js"></script>

--- a/sz-acl.html
+++ b/sz-acl.html
@@ -190,7 +190,7 @@
     </main>
 
     <footer class="footer" role="contentinfo">
-        © 2025 NeuralConfig LLC | <a href="mailto:contact@neuralconfig.com">contact@neuralconfig.com</a>
+        © 2025-2026 NeuralConfig LLC | <a href="mailto:contact@neuralconfig.com">contact@neuralconfig.com</a>
     </footer>
     <script data-goatcounter="https://neuralconfig.goatcounter.com/count"
             async src="//gc.zgo.at/count.js"></script>

--- a/wifi-test.html
+++ b/wifi-test.html
@@ -228,7 +228,7 @@
     </main>
 
     <footer class="footer" role="contentinfo">
-        © 2025 NeuralConfig LLC | <a href="mailto:contact@neuralconfig.com">contact@neuralconfig.com</a>
+        © 2025-2026 NeuralConfig LLC | <a href="mailto:contact@neuralconfig.com">contact@neuralconfig.com</a>
     </footer>
     <script data-goatcounter="https://neuralconfig.goatcounter.com/count"
             async src="//gc.zgo.at/count.js"></script>

--- a/wispr-portal.html
+++ b/wispr-portal.html
@@ -388,7 +388,7 @@
     </main>
 
     <footer class="footer" role="contentinfo">
-        © 2025 NeuralConfig LLC | <a href="mailto:contact@neuralconfig.com" style="color: var(--accent); text-decoration: none;">contact@neuralconfig.com</a>
+        © 2025-2026 NeuralConfig LLC | <a href="mailto:contact@neuralconfig.com" style="color: var(--accent); text-decoration: none;">contact@neuralconfig.com</a>
     </footer>
 
     <script src="matrix.js" defer></script>


### PR DESCRIPTION
## Summary
- Rebuilt CLI auto-play from 16 to 8 focused commands, removing hallucinated data (stats.json) and theater commands (systemctl, docker ps, kubectl, terraform, git log, tail)
- Added `python -m jira_analyzer --stages` command showcasing the Qwen3-30B-A3B pipeline
- Removed survival-rag from tree listing and interactive project list
- Updated interactive whoami to emphasize networking/wireless/security over Kubernetes/cloud
- Skills page story and timeline now lead with network infrastructure background
- Moved openrouter-chat-app and survival-rag to end of projects grid

## Test plan
- [ ] Auto-play runs 8 commands: whoami → tree (5 projects) → mission → hint → skills → jira-analyzer stages → safety → services
- [ ] No hallucinated stats or theater commands appear
- [ ] No survival-rag in tree or interactive projects list
- [ ] Interactive `whoami` shows networking/wireless/security
- [ ] skills.html story leads with network infrastructure
- [ ] projects.html: openrouter-chat-app and survival-rag are last two cards
- [ ] jira-analyzer stages references Qwen3-30B-A3B